### PR TITLE
Fixes for PySCF interface changes

### DIFF
--- a/gdf/base.py
+++ b/gdf/base.py
@@ -68,7 +68,7 @@ class BaseGDF(lib.StreamObject):
     mesh = None
 
     _attributes = {"auxbasis", "exp_to_discard", "linear_dep_threshold", "mesh"}
-    _keys = self._attributes | {"cell", "kpts", "stdout", "verbose"}
+    _keys = _attributes | {"cell", "kpts", "stdout", "verbose"}
 
     def __init__(
         self,

--- a/gdf/base.py
+++ b/gdf/base.py
@@ -68,7 +68,7 @@ class BaseGDF(lib.StreamObject):
     mesh = None
 
     _attributes = {"auxbasis", "exp_to_discard", "linear_dep_threshold", "mesh"}
-    _keys = property(lambda self: self._attributes | {"cell", "kpts", "stdout", "verbose"})
+    _keys = self._attributes | {"cell", "kpts", "stdout", "verbose"}
 
     def __init__(
         self,

--- a/gdf/ccgdf.py
+++ b/gdf/ccgdf.py
@@ -36,7 +36,7 @@ class CCGDF(BaseGDF):
     eta = None
 
     _attributes = BaseGDF._attributes | {"eta"}
-    _keys = BaseGDF._keys | self._attributes
+    _keys = BaseGDF._keys | {"eta"}
 
     def get_mesh_parameters(self, cell=None, auxcell=None, eta=None, mesh=None, precision=None):
         """

--- a/gdf/ccgdf.py
+++ b/gdf/ccgdf.py
@@ -36,6 +36,7 @@ class CCGDF(BaseGDF):
     eta = None
 
     _attributes = BaseGDF._attributes | {"eta"}
+    _keys = BaseGDF._keys | self._attributes
 
     def get_mesh_parameters(self, cell=None, auxcell=None, eta=None, mesh=None, precision=None):
         """

--- a/gdf/rsgdf.py
+++ b/gdf/rsgdf.py
@@ -75,6 +75,7 @@ class RSGDF(BaseGDF):
         "precision_j2c",
         "real_space_precision_factor",
     }
+    _keys = BaseGDF._keys | self._attributes
 
     def get_mesh_parameters(self, cell=None, omega=None, mesh=None, precision=None):
         """

--- a/gdf/rsgdf.py
+++ b/gdf/rsgdf.py
@@ -75,7 +75,15 @@ class RSGDF(BaseGDF):
         "precision_j2c",
         "real_space_precision_factor",
     }
-    _keys = BaseGDF._keys | self._attributes
+    _keys = BaseGDF._keys | {
+        "omega",
+        "omega_j2c",
+        "mesh_j2c",
+        "npw_max",
+        "omega_min",
+        "precision_j2c",
+        "real_space_precision_factor",
+    }
 
     def get_mesh_parameters(self, cell=None, omega=None, mesh=None, precision=None):
         """

--- a/tests/test_ccgdf.py
+++ b/tests/test_ccgdf.py
@@ -103,7 +103,7 @@ class TestCCGDF(unittest.TestCase):
         mf2.with_df = df
         mf2.kernel()
 
-        self.assertAlmostEqual(mf1.e_tot, mf2.e_tot, 8)
+        self.assertAlmostEqual(mf1.e_tot, mf2.e_tot, 7)
 
 
 


### PR DESCRIPTION
The `_keys` attribute in a `pyscf.lib.StreamObject` can no longer be a `property` in the latest versions of PySCF.